### PR TITLE
Change FileDialog in import screen to EditorFileDialog for extra features.

### DIFF
--- a/package_import_dialog.gd
+++ b/package_import_dialog.gd
@@ -33,7 +33,7 @@ var asset_adapter = asset_adapter_class.new()
 var object_adapter = object_adapter_class.new()
 
 var main_dialog: AcceptDialog = null
-var file_dialog: FileDialog = null
+var file_dialog: EditorFileDialog = null
 var main_dialog_tree: Tree = null
 
 var spinner_icon: AnimatedTexture = null
@@ -492,12 +492,12 @@ func show_reimport() -> void:
 
 
 func show_importer() -> void:
-	file_dialog = FileDialog.new()
+	file_dialog = EditorFileDialog.new()
 	file_dialog.set_title("Import Unity Package...")
 	file_dialog.add_filter("*.unitypackage")
-	file_dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
+	file_dialog.file_mode = EditorFileDialog.FILE_MODE_OPEN_FILE
 	# FILE_MODE_OPEN_FILE = 0  –  The dialog allows selecting one, and only one file.
-	file_dialog.access = FileDialog.ACCESS_FILESYSTEM
+	file_dialog.access = EditorFileDialog.ACCESS_FILESYSTEM
 	file_dialog.file_selected.connect(self._selected_package)
 	EditorPlugin.new().get_editor_interface().get_base_control().add_child(file_dialog, true)
 	_show_importer_common()


### PR DESCRIPTION
While experimenting with different pipeline approaches I had to use the file picker dialog quite a few times and was really missing the Recents and Favourites sidebar to quickly navigate to the folder where .unitypackage files are stored. These are available if we use [EditorFileDialog](https://docs.godotengine.org/en/stable/classes/class_editorfiledialog.html) instead of vanilla FileDialog.

This tiny PR does exactly this^^

Fig 1.
![Screenshot 2023-11-09 010949](https://github.com/V-Sekai/unidot_importer/assets/10573379/7783466f-d8e7-42c5-bb97-9747422e19a4)
